### PR TITLE
docs: fix command to run unit tests with melos

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This project uses [melos](https://github.com/invertase/melos) to manage all the 
 
 - Format `melos run format`
 - Analyze `melos run analyze`
-- Test `melos run test`
+- Test `melos run unittest`
 - Pub get `melos run get`
 
 ##### Publishing


### PR DESCRIPTION
For beginner contributor who tries to follow the readme and may came across below error while running current command.

current command
```
melos run test
```

response - error
```
ScriptNotFoundException: The script test could not be found in the 'melos.yaml' file.
 - analyze
 - format
 - get
 - unittest
 ```
 
updated command as per melos configurations
```
melos run unittest
```